### PR TITLE
Unsnooze OSCAR source

### DIFF
--- a/backend/scripts/status.js
+++ b/backend/scripts/status.js
@@ -57,7 +57,6 @@ up.assert(
 up.assert(
   state.sources.oscar, 'date',
   8 * days, 'OSCAR is delayed',
-  true,
 );
 up.assert(
   state.sources.rtgssthr, 'date',


### PR DESCRIPTION
Merge this once `OSCAR is delayed. [snoozed]` stops appearing in [status check logs](https://github.com/byrd-polar/fluid-earth/actions/workflows/tera-status-check.yml).