### PR TITLE
Fix particle rendering on some mobile devices

### DIFF
--- a/src/map/particle/draw.vert
+++ b/src/map/particle/draw.vert
@@ -2,11 +2,12 @@
 // Vertex shader for the particle data layer
 //
 // essentially the same as the vertex shader for the vector layer
+precision highp isampler2D;
 
 #pragma glslify: forwardProject = require(../projections/forward.glsl)
 
 in vec2 a_particleIndex;
-uniform sampler2D u_particlePositions;
+uniform isampler2D u_particlePositions;
 uniform float u_particleCountSqrt;
 
 uniform float u_canvasRatio;
@@ -30,7 +31,7 @@ void main() {
   vec2 lonLat0 = radians(vec2(u_lon0, u_lat0));
 
   vec2 texCoord = a_particleIndex / u_particleCountSqrt;
-  vec4 data = texture(u_particlePositions, texCoord);
+  vec4 data = intBitsToFloat(texture(u_particlePositions, texCoord));
   vec2 lonLat = radians(data.rg);
   v_speed = data.a;
 

--- a/src/map/particle/simulator.js
+++ b/src/map/particle/simulator.js
@@ -21,7 +21,6 @@ export default class ParticleSimulator {
     this._gl = gl;
     this._gl.enable(gl.BLEND);
     this._gl.getExtension('OES_texture_float_linear');
-    this._gl.getExtension('EXT_color_buffer_float');
 
     this._programs = this._createPrograms();
     this._buffers = this._createBuffers();
@@ -242,28 +241,30 @@ export default class ParticleSimulator {
 
   _createSimATexture() {
     return twgl.createTexture(this._gl, {
-      type: this._gl.FLOAT,
-      format: this._gl.RGBA,
-      internalFormat: this._gl.RGBA32F,
+      type: this._gl.INT,
+      format: this._gl.RGBA_INTEGER,
+      internalFormat: this._gl.RGBA32I,
       minMag: this._gl.NEAREST,
       width: Math.sqrt(this._count),
       height: Math.sqrt(this._count),
-      src: Float32Array.from({ length: this._count * 4 }, (_, i) => {
-        switch(i % 4) {
-          case 0: return randlon();
-          case 1: return randlat();
-          case 2: return this._lifetime * Math.random();
-          default: return 0;
-        }
-      }),
+      src: new Int32Array(
+        Float32Array.from({ length: this._count * 4 }, (_, i) => {
+          switch(i % 4) {
+            case 0: return randlon();
+            case 1: return randlat();
+            case 2: return this._lifetime * Math.random();
+            default: return 0;
+          }
+        }).buffer
+      ),
     });
   }
 
   _createSimBTexture() {
     return twgl.createTexture(this._gl, {
-      type: this._gl.FLOAT,
-      format: this._gl.RGBA,
-      internalFormat: this._gl.RGBA32F,
+      type: this._gl.INT,
+      format: this._gl.RGBA_INTEGER,
+      internalFormat: this._gl.RGBA32I,
       minMag: this._gl.NEAREST,
       width: Math.sqrt(this._count),
       height: Math.sqrt(this._count),

--- a/src/map/particle/step.frag
+++ b/src/map/particle/step.frag
@@ -4,7 +4,7 @@ precision highp float;
 
 #pragma glslify: projectToTexture = require(../data-projections/)
 
-uniform sampler2D u_particleData;
+uniform highp isampler2D u_particleData;
 uniform sampler2D u_vectorFieldU;
 uniform sampler2D u_vectorFieldV;
 uniform sampler2D u_random;
@@ -20,7 +20,7 @@ uniform float u_timeDelta;
 uniform float u_rate;
 
 in vec2 v_position;
-out vec4 color;
+out ivec4 color;
 
 const vec2 DIM = vec2(360.0, 180.0); // size of map in longitude and latitude
 const vec2 DIM_2 = vec2(180.0, 90.0);
@@ -29,7 +29,7 @@ const float M_PER_DEG = 111319.5;
 
 void main() {
   vec2 id = (v_position + 1.0) / 2.0; // 2D "id" in between (0,0) and (1,1)
-  vec4 data = texture(u_particleData, id);
+  vec4 data = intBitsToFloat(texture(u_particleData, id));
   vec2 lonLat = data.rg;
   float lifetime = data.b + u_timeDelta;
 
@@ -68,5 +68,5 @@ void main() {
   lonLat.x = mod(lonLat.x + DIM_2.x, DIM.x) - DIM_2.x;
   lonLat.y = clamp(lonLat.y, -DIM_2.y, DIM_2.y);
 
-  color = vec4(lonLat, lifetime, speed);
+  color = floatBitsToInt(vec4(lonLat, lifetime, speed));
 }


### PR DESCRIPTION
Before:
![bs_realdroid_Mobile_Samsung Galaxy S20-10 0-1440x3200](https://user-images.githubusercontent.com/47396035/208050104-5b269516-7446-4033-8ef9-ce67c59a2394.jpg)

After:
![bs_realdroid_Mobile_Samsung Galaxy S20-10 0-1440x3200-2](https://user-images.githubusercontent.com/47396035/208050093-1e0cc929-79fa-46b1-90c0-2807aba55085.jpg)


Removes the dependency on the EXT_color_buffer_float extension by using integer textures and bit conversions instead of float textures.

In more detail: some mobile devices (e.g. Galaxy S20) fail the [conformance test](https://registry.khronos.org/webgl/sdk/tests/conformance2/extensions/ext-color-buffer-float.html?webglVersion=2&quiet=0&quick=1) for the above extension and so render the particles incorrectly. By avoiding the extension, the majority of the rendering issues are hopefully fixed.