### PR TITLE
Add fallback when linear filter is not available

### DIFF
--- a/src/map/particle/simulator.js
+++ b/src/map/particle/simulator.js
@@ -20,7 +20,7 @@ export default class ParticleSimulator {
     // private variables (no setters)
     this._gl = gl;
     this._gl.enable(gl.BLEND);
-    this._gl.getExtension('OES_texture_float_linear');
+    this._linearFiltering = this._gl.getExtension('OES_texture_float_linear');
 
     this._programs = this._createPrograms();
     this._buffers = this._createBuffers();
@@ -279,7 +279,7 @@ export default class ParticleSimulator {
       type:           halfFloat ? this._gl.HALF_FLOAT : this._gl.FLOAT,
       internalFormat: halfFloat ? this._gl.R16F : this._gl.R32F,
       format: this._gl.RED,
-      minMag: this._gl.LINEAR,
+      minMag: this._linearFiltering ? this._gl.LINEAR : this._gl.NEAREST,
       width: this._data.width,
       height: this._data.height,
     });


### PR DESCRIPTION
Follow up to #11. More for completeness than anything else; extends our support to any device that supports the base WebGL2 spec without extensions. 