### PR TITLE
Fix shaders not being compressed in prod build

### DIFF
--- a/patches/rollup-plugin-glslify+1.3.1.patch
+++ b/patches/rollup-plugin-glslify+1.3.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/rollup-plugin-glslify/index.js b/node_modules/rollup-plugin-glslify/index.js
-index 85474ec..2c1e423 100644
+index 85474ec..75f9c8a 100644
 --- a/node_modules/rollup-plugin-glslify/index.js
 +++ b/node_modules/rollup-plugin-glslify/index.js
 @@ -58,7 +58,12 @@ module.exports = function glslify(userOptions = {}) {
@@ -16,12 +16,3 @@ index 85474ec..2c1e423 100644
  
              if (typeof options.compress === 'function') {
                  code = options.compress(code);
-@@ -67,7 +72,7 @@ module.exports = function glslify(userOptions = {}) {
-             }
- 
-             return {
--                code: `export default ${JSON.stringify(code)}; // eslint-disable-line`,
-+                code: `export default ${JSON.stringify(source)}; // eslint-disable-line`,
-                 map: { mappings: '' }
-             };
-         }


### PR DESCRIPTION
**Update:** please review #15 first

Caused by typo in patch that enables HMR for glslify

**Note:** due to what seems to be a bug in patch-package, `npm i` will appear to update the patch while not actually doing anything — you will need to manually delete the `node_modules` directory and run `npm i` again.

Before:
```
dist/assets/index-20fd6ca7.js   727.23 kB │ gzip: 219.73 kB 
```

After:
```
dist/assets/index-8ea5ae17.js   704.92 kB │ gzip: 217.05 kB 
```
