### PR TITLE
Fix flickering of vector lines on some projections

### DIFF
--- a/src/map/projections/forward.glsl
+++ b/src/map/projections/forward.glsl
@@ -26,6 +26,8 @@ void forwardProject(
     lonLat0.y = 0.0;
   }
 
+  clip = false;
+
   if (projection == 0) {
     p0(displayCoord, lonLat0, lonLat);
   } else if (projection == 1) {


### PR DESCRIPTION
Apparently clip not having an explicit default value causes the varying to take on seemingly random values, leading to some lines not being rendered some of the time as the map is being zoomed and panned

Only affected the equirectangular and stereographic projections and only on some Linux and Mac devices