### PR TITLE
Preload render-blocking resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
   <link rel="manifest" href="/site.webmanifest">
   <link rel="mask-icon" href="/images/safari-pinned-tab.svg" color="#173e41">
   <link rel="shortcut icon" href="/images/favicon.ico">
+  <link rel="preload" href="/tera/inventory.json.br" as="fetch">
+  <link rel="preload" href="/tera/topology.json.br" as="fetch">
 
   <meta name="theme-color" content="#173e41">
   <meta property="og:title" content="Fluid Earth">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,7 +27,7 @@
   import { simplify, translate } from './smode.js';
   import { currentDate, mobile } from './stores.js';
   import { getUnitFromDial } from './units.js';
-  import { fetchJson } from './utility.js';
+  import { fetchPreloadedJson } from './utility.js';
 
   import Help from 'carbon-icons-svelte/lib/Help.svelte';
   import Location from 'carbon-icons-svelte/lib/Location.svelte';
@@ -225,7 +225,7 @@
   fetchVectorData().then(fadeSplashScreen);
 
   async function fetchVectorData() {
-    vectorData = await fetchJson('/tera/topology.json.br');
+    vectorData = await fetchPreloadedJson('/tera/topology.json.br');
     vectorColors = {
       ne_50m_coastline: [255, 255, 255, 1],
       ne_50m_lakes: [255, 255, 255, 1],

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,10 @@
 import './app.css';
 import App from './App.svelte';
 import { GriddedDataset, ParticleDataset } from './datasets.js';
-import { fetchJson } from './utility.js';
+import { fetchPreloadedJson } from './utility.js';
 
 (async () => {
-  let inventory = await fetchJson('/tera/inventory.json.br', {
-    headers: { 'Cache-Control': 'no-cache' },
-  });
+  let inventory = await fetchPreloadedJson('/tera/inventory.json.br');
 
   let gDatasets = [...GriddedDataset.filter(inventory), GriddedDataset.none];
   let pDatasets = [...ParticleDataset.filter(inventory), ParticleDataset.none];

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,3 +1,10 @@
+export async function fetchPreloadedJson(url) {
+  return fetchJson(url, {
+    mode: 'no-cors',
+    credentials: 'include',
+  })
+}
+
 export async function fetchJson(url, options) {
   let response = await fetch(url, options);
   throwIfNotOk(response);


### PR DESCRIPTION
Noticeably reduces the time the splash screen remains visible on initial page load.

Tested on Firefox, Safari, and Chromium, all of which are a bit picky with regards to the CORS and credential modes for the fetch request to match the preload.

Seems to preserve the behavior of checking if the requested files were updated on the server before using the cached response previously declared by `headers: { 'Cache-Control': 'no-cache' }`.