### PR TITLE
Fix side controls breaking rest of widget layout

### DIFF
--- a/src/components/SideControls.svelte
+++ b/src/components/SideControls.svelte
@@ -108,7 +108,8 @@
     background: var(--secondary-color-dark);
     display: flex;
     flex-direction: column;
-    margin-left: auto;
+    gap: 8px;
+    margin: auto 0 auto auto;
     pointer-events: auto;
     padding: 8px 4px 8px 8px;
     border-radius: 24px 0 0 24px;
@@ -123,10 +124,6 @@
     padding: 8px;
     cursor: pointer;
     transition: filter 0.25s ease 0s;
-  }
-
-  button + button {
-    margin-top: 8px;
   }
 
   button:focus, button:hover {

--- a/src/overlays/Widgets.svelte
+++ b/src/overlays/Widgets.svelte
@@ -48,15 +48,6 @@
       bind:utc
     />
   </div>
-  {#if !$mobile}
-    <SideControls
-      bind:centerLatitude
-      bind:centerLongitude
-      bind:zoom
-      {minZoom}
-      {maxZoom}
-    />
-  {/if}
   <div class="bottom">
     {#if griddedName !== 'none'}
       <GriddedLegend
@@ -84,6 +75,17 @@
     {/if}
   </div>
 </div>
+{#if !$mobile}
+  <div class="side-controls-wrapper">
+    <SideControls
+      bind:centerLatitude
+      bind:centerLongitude
+      bind:zoom
+      {minZoom}
+      {maxZoom}
+    />
+  </div>
+{/if}
 
 <style>
   div :global(h3),
@@ -115,6 +117,10 @@
 
   div.bottom {
     flex-wrap: wrap-reverse;
+  }
+
+  div.side-controls-wrapper {
+    pointer-events: none;
   }
 
   @media (max-width: 576px) {


### PR DESCRIPTION
Was causing the legend widgets to fall off the screen when height was small, e.g. landscape mode on mobile

Also keeps side controls centered vertically instead of shifting when other widgets move