### PR TITLE
Fix storage leak

### DIFF
--- a/backend/download.js
+++ b/backend/download.js
@@ -27,7 +27,7 @@ export async function destructive_cat(files) {
       for await (let chunk of stream) yield chunk;
   }, createWriteStream(file));
 
-  for (let input_file of files) await rm(input_file);
+  await Promise.all(files.map(input_file => rm(input_file)));
 
   return file;
 }

--- a/backend/sources/era5monthly.js
+++ b/backend/sources/era5monthly.js
@@ -89,6 +89,7 @@ async function get_normal(normals, dt, variable) {
   normals[variable][month] = output;
 
   await grib1_normal(count, input, output, { record_number: 'all' });
+  await rm(input);
 
   return output;
 }


### PR DESCRIPTION
Previously forgot to have the ERA5 source remove some of its downloaded temp files, causing the temp dir file system to fill up. Fixes that and also includes a slight optimization for GFS.

To ensure there are no remaining unneeded temp files, stop Tera, remove the `/tmp/fev2r-cache` dir, apply this update, then restart Tera.