### PR TITLE
Fix storage leak, take two

### DIFF
--- a/backend/download.js
+++ b/backend/download.js
@@ -1,14 +1,13 @@
-import { temp_cache_dir } from './utility.js';
+import { get_temp_file } from './utility.js';
 import { Buffer } from 'buffer';
 import { createReadStream, createWriteStream } from 'fs';
 import { rm, writeFile } from 'fs/promises';
 import { get, request } from 'https';
 import { join, basename } from 'path';
 import { pipeline } from 'stream/promises';
-import { v4 as uuidv4 } from 'uuid';
 
 export async function download(url, options={}, unique_path=true) {
-  let file = join(temp_cache_dir, unique_path ? uuidv4() : basename(url));
+  let file = get_temp_file(unique_path ? undefined : basename(url));
   let response = await download_as_stream(url, options);
 
   if (response.headers['content-type'].startsWith('multipart/byteranges')) {
@@ -20,7 +19,7 @@ export async function download(url, options={}, unique_path=true) {
 }
 
 export async function destructive_cat(files) {
-  let file = join(temp_cache_dir, uuidv4());
+  let file = get_temp_file();
 
   await pipeline(async function* () {
     for (let stream of files.map(input_file => createReadStream(input_file)))

--- a/backend/file-conversions.js
+++ b/backend/file-conversions.js
@@ -1,10 +1,9 @@
-import { brotli, temp_cache_dir, write_file_atomically } from './utility.js';
+import { brotli, get_temp_file, write_file_atomically } from './utility.js';
 import { Float16Array } from '@petamoriken/float16';
 import { Buffer } from 'buffer';
 import { spawn } from 'child_process';
 import { readFile, rm } from 'fs/promises';
 import { join } from 'path';
-import { v4 as uuidv4 } from 'uuid';
 
 export async function grib1(input, output, options={}) {
   let arr = await grib1_to_arr(input, options.record_number);
@@ -87,7 +86,7 @@ async function gfs_combine_grib(input, output, options, combine_fn) {
 }
 
 async function grib1_to_arr(input, record_number=1) {
-  let temp_file = join(temp_cache_dir, uuidv4());
+  let temp_file = get_temp_file();
   await spawn_cmd('wgrib', [
     input,
     '-d', record_number,

--- a/backend/sources/era5monthly.js
+++ b/backend/sources/era5monthly.js
@@ -34,6 +34,11 @@ export async function forage(current_state, datasets) {
   let metadatas = datasets.map(d => typical_metadata(d, dt, shared_metadata));
   let variables = [...new Set(datasets.map(d => d.variable))];
 
+  // Work around an issue with the CDS API where data for certain months is
+  // truncated if variables are in a particular order (e.g. total_precipitation
+  // before 2m_temperature for 2023-02)
+  variables.sort();
+
   let input;
   try {
     input = await download_cds(name, {


### PR DESCRIPTION
Fixes both the original cause of failure and failures in general leaving behind temp files.

Issue in the CDS API has [been reported](https://jira.ecmwf.int/plugins/servlet/desk/portal/4/SD-76652). (Link is a note-to-self, requires login.)