### PR TITLE
Temporarily fix OSCAR data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ content, replacing the `X`s with your key:
 CDS_API_KEY=XXXXXX:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 ```
 
+Similarly, [create an account](https://urs.earthdata.nasa.gov/users/new) to
+access Earthdata, and add your username and password to `.env`:
+
+```env
+EARTHDATA_LOGIN=username:password
+```
+
 Finally, in a separate terminal tab/window:
 
 ```sh

--- a/backend/download.js
+++ b/backend/download.js
@@ -6,14 +6,19 @@ import { get, request } from 'https';
 import { join, basename } from 'path';
 import { pipeline } from 'stream/promises';
 
-export async function download(url, options={}, unique_path=true) {
+export async function download(
+  url,
+  options={},
+  unique_path=true,
+  transforms=[],
+) {
   let file = get_temp_file(unique_path ? undefined : basename(url));
   let response = await download_as_stream(url, options);
 
   if (response.headers['content-type'].startsWith('multipart/byteranges')) {
     await multipart_byteranges_to_file(file, response);
   } else {
-    await pipeline(response, createWriteStream(file));
+    await pipeline(response, ...transforms, createWriteStream(file));
   }
   return file;
 }

--- a/backend/download.js
+++ b/backend/download.js
@@ -56,7 +56,12 @@ export async function post_json(url, json, options={}) {
 
 async function download_as_stream(url, options={}) {
   return new Promise((resolve, reject) => {
-    get(url, options, res => handle_response(res, resolve, reject, url))
+    // handle redirects
+    const callback = res => res.headers.location
+      ? get(res.headers.location, options, callback)
+          .on('error', reject)
+      : handle_response(res, resolve, reject, url);
+    get(url, options, callback)
       .on('error', reject);
   });
 }

--- a/backend/download.js
+++ b/backend/download.js
@@ -62,7 +62,7 @@ export async function post_json(url, json, options={}) {
 async function download_as_stream(url, options={}) {
   return new Promise((resolve, reject) => {
     // handle redirects
-    const callback = res => res.headers.location
+    const callback = res => [301, 302, 303, 307, 308].includes(res.statusCode)
       ? get(res.headers.location, options, callback)
           .on('error', reject)
       : handle_response(res, resolve, reject, url);

--- a/backend/sources/oscar.js
+++ b/backend/sources/oscar.js
@@ -1,7 +1,9 @@
 import { Datetime } from '../datetime.js';
-import { download } from '../download.js';
+import { download, get_json, post_json } from '../download.js';
 import { typical_metadata, output_path } from '../utility.js';
 import { rm } from 'fs/promises';
+import { createGunzip } from 'zlib';
+import 'dotenv/config'
 
 const reference_datetime = Datetime.from('1992-10-05');
 
@@ -21,10 +23,14 @@ export async function forage(current_state, datasets) {
 
   let metadatas = datasets.map(d => typical_metadata(d, dt, shared_metadata));
 
+  let token = await get_token(process.env.EARTHDATA_LOGIN);
   let input = await download(
-    'https://podaac-opendap.jpl.nasa.gov/'
-    + 'opendap/allData/oscar/preview/L4/oscar_third_deg/'
-    + `oscar_vel${dt.days_since(reference_datetime)}.nc.gz.nc4`
+    'https://archive.podaac.earthdata.nasa.gov/'
+    + 'podaac-ops-cumulus-protected/OSCAR_L4_OC_third-deg/'
+    + `oscar_vel${dt.days_since(reference_datetime)}.nc.gz`,
+    { headers: { Authorization: `Bearer ${token}` } },
+    true,
+    [createGunzip()],
   );
 
   await Promise.all(datasets.map(async dataset => {
@@ -34,4 +40,21 @@ export async function forage(current_state, datasets) {
   await rm(input);
 
   return { metadatas, new_state: { date } };
+}
+
+// See: https://urs.earthdata.nasa.gov/documentation/for_users/user_token#api
+const api_url = 'https://urs.earthdata.nasa.gov/api/users';
+
+async function get_token(earthdata_login) {
+  let headers = { Authorization: `Basic ${btoa(earthdata_login)}` };
+
+  let [{ access_token, expiration_date }] =
+    await get_json(`${api_url}/tokens`, { headers });
+
+  if (Datetime.now() > new Datetime(expiration_date).subtract({ days: 5 })) {
+    let params = new URLSearchParams({ token: access_token });
+    await post_json(`${api_url}/revoke_token?${params}`, {}, { headers });
+    ({ access_token } = await post_json(`${api_url}/token`, {}, { headers }));
+  }
+  return access_token;
 }


### PR DESCRIPTION
This gets the existing data source working again and lays the foundation for upgrading to OSCAR v2 in the future.

Earthdata handles tokens a bit strangely — all tokens expire after 90 days so instead of an API key, the user's password is needed as an environmental variable to create tokens on the fly if needed. This is the same approach taken by https://github.com/podaac/data-subscriber.