### PR TITLE
Upgrade to OSCAR2 data source

### DIFF
--- a/backend/datasets/oscar2-speed.js
+++ b/backend/datasets/oscar2-speed.js
@@ -1,0 +1,3 @@
+export const name = 'ocean surface currents speed v2';
+
+export { metadata, convert } from './oscar-speed.js';

--- a/backend/datasets/oscar2-velocity.js
+++ b/backend/datasets/oscar2-velocity.js
@@ -1,0 +1,3 @@
+export const name = 'ocean surface currents v2';
+
+export { metadata, convert } from './oscar-velocity.js';

--- a/backend/rabbit.js
+++ b/backend/rabbit.js
@@ -27,7 +27,7 @@ let state_file = join(sources_state_dir, `${source}.json`);
 let current_state = await read_json(state_file, {});
 
 let dataset_files = (await readdir(datasets_dir))
-  .filter(file => basename(file, '.js').split('-')[0] === source);
+  .filter(file => basename(file, '.js').split('-')[0] === source.split('-')[0]);
 
 let datasets = (await Promise.all(dataset_files.map(async file => {
   let filename = basename(file, '.js');

--- a/backend/sources/oscar.js
+++ b/backend/sources/oscar.js
@@ -45,7 +45,7 @@ export async function forage(current_state, datasets) {
 // See: https://urs.earthdata.nasa.gov/documentation/for_users/user_token#api
 const api_url = 'https://urs.earthdata.nasa.gov/api/users';
 
-async function get_token(earthdata_login) {
+export async function get_token(earthdata_login) {
   let headers = { Authorization: `Basic ${btoa(earthdata_login)}` };
 
   let [{ access_token, expiration_date }] =

--- a/backend/sources/oscar2-final.js
+++ b/backend/sources/oscar2-final.js
@@ -12,10 +12,20 @@ const shared_metadata = {
 };
 
 export async function forage(current_state, datasets) {
+  return oscar2(current_state, datasets, 'final');
+}
+
+const start_years = {
+  final: 1993,
+  interim: 2020,
+  nrt: 2021,
+};
+
+export async function oscar2(current_state, datasets, quality) {
   let { date } = current_state;
   let dt = date
     ? Datetime.from(date).add({ days: 1 })
-    : Datetime.from('1993-01-01T00:00:00.000Z');
+    : Datetime.from(`${start_years[quality]}-01-01T00:00:00.000Z`);
   date = dt.to_iso_string();
 
   let metadatas = datasets.map(d => typical_metadata(d, dt, shared_metadata));
@@ -23,8 +33,9 @@ export async function forage(current_state, datasets) {
   let token = await get_token(process.env.EARTHDATA_LOGIN);
   let input = await download(
     'https://archive.podaac.earthdata.nasa.gov/'
-    + 'podaac-ops-cumulus-protected/OSCAR_L4_OC_FINAL_V2.0/'
-    + `oscar_currents_final_${dt.year}${dt.p_month}${dt.p_day}.nc`,
+    + 'podaac-ops-cumulus-protected/'
+    + `OSCAR_L4_OC_${quality.toUpperCase()}_V2.0/`
+    + `oscar_currents_${quality}_${dt.year}${dt.p_month}${dt.p_day}.nc`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
 

--- a/backend/sources/oscar2-final.js
+++ b/backend/sources/oscar2-final.js
@@ -1,0 +1,38 @@
+import { Datetime } from '../datetime.js';
+import { download } from '../download.js';
+import { typical_metadata, output_path } from '../utility.js';
+import { get_token } from './oscar.js';
+import { rm } from 'fs/promises';
+
+const shared_metadata = {
+  width: 719,
+  height: 1440,
+  interval: 'daily-aggregate',
+  projection: 'OSCAR2',
+};
+
+export async function forage(current_state, datasets) {
+  let { date } = current_state;
+  let dt = date
+    ? Datetime.from(date).add({ days: 1 })
+    : Datetime.from('1993-01-01T00:00:00.000Z');
+  date = dt.to_iso_string();
+
+  let metadatas = datasets.map(d => typical_metadata(d, dt, shared_metadata));
+
+  let token = await get_token(process.env.EARTHDATA_LOGIN);
+  let input = await download(
+    'https://archive.podaac.earthdata.nasa.gov/'
+    + 'podaac-ops-cumulus-protected/OSCAR_L4_OC_FINAL_V2.0/'
+    + `oscar_currents_final_${dt.year}${dt.p_month}${dt.p_day}.nc`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  await Promise.all(datasets.map(async dataset => {
+    let output = output_path(dataset.output_dir, date);
+    await dataset.convert(input, output, { variables: 'u,v' });
+  }));
+  await rm(input);
+
+  return { metadatas, new_state: { date } };
+}

--- a/backend/sources/oscar2-interim.js
+++ b/backend/sources/oscar2-interim.js
@@ -1,0 +1,5 @@
+import { oscar2 } from './oscar2-final.js';
+
+export async function forage(current_state, datasets) {
+  return oscar2(current_state, datasets, 'interim');
+}

--- a/backend/sources/oscar2-nrt.js
+++ b/backend/sources/oscar2-nrt.js
@@ -1,0 +1,5 @@
+import { oscar2 } from './oscar2-final.js';
+
+export async function forage(current_state, datasets) {
+  return oscar2(current_state, datasets, 'nrt');
+}

--- a/backend/utility.js
+++ b/backend/utility.js
@@ -129,7 +129,7 @@ export function output_path(output_dir, iso_date_string) {
 
 export function typical_metadata(dataset, dt, shared_metadata) {
   let { start, end, missing } = dataset.current_state;
-  start ??= dt.to_iso_string();
+  start = !start || dt < Datetime.from(start) ? dt.to_iso_string() : start;
   end = !end || dt > Datetime.from(end) ? dt.to_iso_string() : end;
   let metadata = dataset.metadata ?? {};
   let new_state = { start, end, missing };

--- a/src/intervals.js
+++ b/src/intervals.js
@@ -23,6 +23,13 @@ export default Object.freeze({
     dateFormat: instantDateFormat,
     timeFormat: instantTimeFormat,
   },
+  'daily-aggregate': {
+    roundTo: { smallestUnit: 'day', roundingMode: 'floor' },
+    duration: { days: 1 },
+    smallestPickerMode: 'day',
+    dateFormat: aggregateDayDateFormat,
+    utcOnly: true,
+  },
   'monthly-aggregate': {
     roundTo: { smallestUnit: 'month', roundingMode: 'floor' },
     duration: { months: 1 },
@@ -42,10 +49,10 @@ export default Object.freeze({
 function instantDateFormat(date, utc) {
   return date.toLocaleDateString([], {
     timeZone: utc ? 'UTC' : undefined,
-    weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    weekday: 'long',
   })
 }
 
@@ -59,6 +66,16 @@ function instantTimeFormat(date, utc) {
   })
   // Fix the toLocaleTimeString output on Chromium-based browsers
   return string === '24:00 UTC' ? '00:00 UTC' : string
+}
+
+function aggregateDayDateFormat(date) {
+   return date.toLocaleDateString([], {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  })
 }
 
 function aggregateMonthDateFormat(date) {

--- a/src/map/data-projections/index.glsl
+++ b/src/map/data-projections/index.glsl
@@ -113,4 +113,15 @@ void projectToTexture(
       textureCoord = vec2(0.0, 0.5);
     }
   }
+  // OSCAR2
+  else if (projection == 5) {
+    textureCoord.x = (lonLat.y + PI_2) / PI;
+    textureCoord.y = lonLat.x / (2.0 * PI);
+
+    float xScale = (gridWidth + 1.0) / gridWidth;
+    float yOffset = 0.5 / gridHeight;
+
+    textureCoord.x = xScale * (textureCoord.x - 0.5) + 0.5;
+    textureCoord.y = mod(textureCoord.y + yOffset, 1.0);
+  }
 }

--- a/src/map/data-projections/index.glsl
+++ b/src/map/data-projections/index.glsl
@@ -1,5 +1,4 @@
 #pragma glslify: export(projectToTexture)
-#pragma glslify: rotate = require(../projections/rotate/forward.glsl)
 
 const float PI = radians(180.0);
 const float PI_2 = radians(90.0);
@@ -13,6 +12,7 @@ void projectToTexture(
 ) {
   // ERA5
   if (projection == -1) {
+
     textureCoord = (lonLat + vec2(0, PI_2)) / vec2(2.0 * PI, PI);
 
     float xOffset = 0.5 / gridWidth;
@@ -38,18 +38,6 @@ void projectToTexture(
     textureCoord = (lonLat + vec2(0, PI_2)) / vec2(2.0 * PI, PI);
     textureCoord.x = mod(textureCoord.x, 1.0);
   }
-  // GEOS
-  else if (projection == 3) {
-
-    textureCoord = (lonLat + vec2(PI, PI_2)) / vec2(2.0 * PI, PI);
-
-    float xOffset = 0.5 / gridWidth;
-    float yScale = (gridHeight - 1.0) / gridHeight;
-
-    textureCoord.x = mod(textureCoord.x + xOffset, 1.0);
-    textureCoord.y = yScale * (textureCoord.y - 0.5) + 0.5;
-
-  }
   // OSCAR
   else if (projection == 2) {
 
@@ -66,6 +54,18 @@ void projectToTexture(
     if (textureCoord.y > 1.0 || textureCoord.y < 0.0) {
       textureCoord = vec2(0.0, 0.5);
     }
+  }
+  // GEOS
+  else if (projection == 3) {
+
+    textureCoord = (lonLat + vec2(PI, PI_2)) / vec2(2.0 * PI, PI);
+
+    float xOffset = 0.5 / gridWidth;
+    float yScale = (gridHeight - 1.0) / gridHeight;
+
+    textureCoord.x = mod(textureCoord.x + xOffset, 1.0);
+    textureCoord.y = yScale * (textureCoord.y - 0.5) + 0.5;
+
   }
   // PERMAFROST
   else if (projection == 4) {

--- a/src/map/data-projections/index.js
+++ b/src/map/data-projections/index.js
@@ -95,6 +95,18 @@ export default Object.freeze({
       return row * data.width + col;
     },
   },
+  OSCAR2: {
+    id: 5,
+    function: (data, lonLat) => {
+      const hRes = data.height / 360;
+      const wRes = (data.width + 1) / 180;
+
+      const row = Math.round((lonLat[0] + 360) * hRes) % data.height;
+      const col = Math.round((lonLat[1] + 90) * wRes - 1);
+
+      return row * data.width + col;
+    },
+  },
 });
 
 // given a griddedData object and a lonLat, return the value at that point


### PR DESCRIPTION
This adds data sources for OSCAR version 2, which increases the spatial (0.33 degrees to 0.25 degrees) and time (~5 days to daily) resolutions compared to the original OSCAR.

Creates new datasets with a `v2` suffix to the name, which won't be accessible via the menus on the front-end for now. Will remove the suffix and rename the original OSCAR datasets once the initial run of all the sources is complete to avoid any time gaps. The initial run should take two to three days, after which I'll open a new PR for the dataset name changes.

The progress of the initial run can be tracked by opening the Developer-Only Tools menu in the local build and selecting the v2 datasets under "All Datasets".