### PR TITLE
Work around OSCAR2 data source race conditions

### DIFF
--- a/backend/utility.js
+++ b/backend/utility.js
@@ -129,7 +129,7 @@ export function output_path(output_dir, iso_date_string) {
 
 export function typical_metadata(dataset, dt, shared_metadata) {
   let { start, end, missing } = dataset.current_state;
-  start = !start || dt < Datetime.from(start) ? dt.to_iso_string() : start;
+  start ??= dt.to_iso_string();
   end = !end || dt > Datetime.from(end) ? dt.to_iso_string() : end;
   let metadata = dataset.metadata ?? {};
   let new_state = { start, end, missing };


### PR DESCRIPTION
Was causing the wrong start and end dates to persist in the outputted dataset metadata; workaround is to put a single source (nrt) in charge of the metadata and skip writing to it for the other two.

Reverts non-working 30c21f829