### PR TITLE
Fix OSCAR2 particle data not displaying correctly

### DIFF
--- a/src/components/datasets/animations.js
+++ b/src/components/datasets/animations.js
@@ -2,7 +2,7 @@ const normal = {
   'wind':
     name => name.startsWith('wind at'),
   'currents':
-    name => name.includes('currents'),
+    name => name === 'ocean surface currents',
   'none':
     name => name === 'none',
 

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -227,6 +227,11 @@ export class ParticleDataset extends Dataset {
   isCloseDate(date) {
     let closest = super.closestValidDate(date)
 
+    // allow latest ocean currents to be displayed with latest ocean temps
+    if (this.name === 'ocean surface currents') {
+      return Math.abs(closest - date) < 4 * 24 * 60 * 60 * 1000
+    }
+
     switch(this.interval) {
       case intervals['custom:NONE']:
         return true


### PR DESCRIPTION
Fixes animation filter not being specific enough and adds a special case for the oscar2-velocity dataset so that it can be displayed alongside sea surface temperatures by default