### PR TITLE
Update status check for OSCAR to OSCAR2

### DIFF
--- a/backend/scripts/status.js
+++ b/backend/scripts/status.js
@@ -49,8 +49,8 @@ up.assert(
   11 * hours, 'GFS-wave is delayed',
 );
 up.assert(
-  state.sources.oscar, 'date',
-  8 * days, 'OSCAR is delayed',
+  state.sources['oscar2-nrt'], 'date',
+  4 * days, 'OSCAR2 is delayed',
 );
 up.assert(
   state.sources.rtgssthr, 'date',


### PR DESCRIPTION
Missed a delay in the data, but that seems to be resolved now. This is a relatively low-priority check since OSCAR2 data files are never deleted, so a 4 day maximum delay is used (above the nominal 2 days).

https://forum.earthdata.nasa.gov/viewtopic.php?t=4383