### PR TITLE
Run GEOS in 'catch-up' mode

### DIFF
--- a/backend/sources/geos.js
+++ b/backend/sources/geos.js
@@ -57,11 +57,9 @@ function max_offset_by_forecast_hour(hour) {
   switch(hour) {
     case 6:
     case 18:
-      return 30;
     case 0:
-      return 240;
     case 12:
-      return 120;
+      return 3;
     default:
       throw `Error: invalid forecast hour: ${hour}`;
   }


### PR DESCRIPTION
Avoid processing files that will be overwritten by newer ones until we are up to date, at which point this commit should be reverted.