### PR TITLE
Add a lower resolution permafrost dataset

### DIFF
--- a/backend/datasets/pangaea-permafrost-lowres.js
+++ b/backend/datasets/pangaea-permafrost-lowres.js
@@ -1,0 +1,8 @@
+export const name = 'permafrost probability [low resolution]';
+
+export const res = '10km';
+
+export const metadata = {
+  width: 2243,
+  height: 2115,
+};

--- a/backend/datasets/pangaea-permafrost.js
+++ b/backend/datasets/pangaea-permafrost.js
@@ -1,1 +1,8 @@
 export const name = 'permafrost probability';
+
+export const res = '5km';
+
+export const metadata = {
+  width: 4485,
+  height: 4229,
+};

--- a/backend/sources/pangaea.js
+++ b/backend/sources/pangaea.js
@@ -3,21 +3,19 @@ import { download } from '../download.js';
 import { netcdf } from '../file-conversions.js';
 import {
   hash_of_this_file,
-  typical_metadata,
+  run_all,
   output_path,
 } from '../utility.js';
 import { rm } from 'fs/promises';
 
 const dt = Datetime.from('2016-01-01');
-const metadata = {
+const shared_metadata = {
   start: dt.to_iso_string(),
   end: dt.to_iso_string(),
   originalUnit: '%',
   unit: '%',
   domain: [0, 100],
   colormap: 'CREST_REVERSED',
-  width: 4485,
-  height: 4229,
   interval: 'yearly-aggregate',
   projection: 'PERMAFROST',
 };
@@ -26,13 +24,19 @@ export async function forage(current_state, datasets) {
   let source_hash = await hash_of_this_file(import.meta);
   if (source_hash === current_state.source_hash) throw 'No update needed';
 
-  let input = await download(
-    'https://store.pangaea.de/Publications/'
-    + 'ObuJ-etal_2018/UiO_PEX_5.0_20181127_2000_2016_5km.nc'
+  let metadatas = datasets.map(
+    ({ metadata }) => ({ ...shared_metadata, ...metadata })
   );
-  let output = output_path(datasets[0].output_dir, dt.to_iso_string());
-  await netcdf(input, output, { variables: 'PerProb', factor: 100 });
-  await rm(input);
 
-  return { metadatas: [metadata], new_state: { source_hash } };
+  await run_all(datasets.map(dataset => async () => {
+    let input = await download(
+      'https://store.pangaea.de/Publications/'
+      + `ObuJ-etal_2018/UiO_PEX_5.0_20181127_2000_2016_${dataset.res}.nc`
+    );
+    let output = output_path(dataset.output_dir, dt.to_iso_string());
+    await netcdf(input, output, { variables: 'PerProb', factor: 100 });
+    await rm(input);
+  }));
+
+  return { metadatas, new_state: { source_hash } };
 }

--- a/src/components/datasets/DatasetInfo.svelte
+++ b/src/components/datasets/DatasetInfo.svelte
@@ -11,6 +11,7 @@
       case 'average precipitation per day anomaly':
         return 'climate_anomolies';
       case 'permafrost probability':
+      case 'permafrost probability [low resolution]':
         return 'permafrost_prob';
       case 'ocean surface currents speed':
         return 'oscar';

--- a/src/components/datasets/topics.js
+++ b/src/components/datasets/topics.js
@@ -26,7 +26,8 @@ const normal = {
          || variableFilters.normal['avg. temperature anomaly'](name)
          || variableFilters.normal['avg. precipitation'](name)
          || variableFilters.normal['avg. precipitation anomaly'](name)
-         || variableFilters.normal['permafrost probability'](name),
+         || variableFilters.normal['permafrost probability'](name)
+         || variableFilters.normal['permafrost (low res.)'](name),
 
   undefined: () => false,
 };

--- a/src/components/datasets/variables.js
+++ b/src/components/datasets/variables.js
@@ -43,6 +43,8 @@ const normal = {
     name => name === 'average precipitation per day anomaly',
   'permafrost probability':
     name => name === 'permafrost probability',
+  'permafrost (low res.)':
+    name => name === 'permafrost probability [low resolution]',
 
   undefined: () => false,
 };
@@ -88,6 +90,8 @@ const simple = {
     name => name === 'average precipitation per day anomaly',
   'permafrost probability':
     name => name === 'permafrost probability',
+  'permafrost (low res.)':
+    name => name === 'permafrost probability [low resolution]',
 
   undefined: () => false,
 };

--- a/src/map/data-projections/index.glsl
+++ b/src/map/data-projections/index.glsl
@@ -100,8 +100,8 @@ void projectToTexture(
     textureCoord.y -= 9199572.4044017550;
     textureCoord /= 926.6254331383;
 
-    // switch from 1 km scale (.tfw file above) to 5 km scale (.nc file)
-    textureCoord /= 5.0;
+    // switch from 1 km scale (.tfw file above) to 5 or 10 km scale (.nc file)
+    textureCoord /= (gridWidth == 4485.0) ? 5.0 : 10.0;
 
     // convert from pixels to texture coords
     textureCoord.x /= gridWidth;

--- a/src/map/data-projections/index.js
+++ b/src/map/data-projections/index.js
@@ -89,8 +89,10 @@ export default Object.freeze({
       let col = m * Math.sin(lonLat[0]);
       let row = -m * Math.cos(lonLat[0]);
 
-      col = Math.floor((col + 10389109.8424841110) / 926.6254331383 / 5);
-      row = Math.floor(-(row - 9199572.4044017550) / 926.6254331383 / 5);
+      let res = data.width === 4485 ? 5 : 10;
+
+      col = Math.floor((col + 10389109.8424841110) / 926.6254331383 / res);
+      row = Math.floor(-(row - 9199572.4044017550) / 926.6254331383 / res);
 
       return row * data.width + col;
     },

--- a/src/units.js
+++ b/src/units.js
@@ -14,7 +14,7 @@ export function prettyValue(value, originalUnit, newUnit, label) {
 }
 
 export function labelByName(value, name) {
-  if (name === 'permafrost probability') {
+  if (name.startsWith('permafrost probability')) {
     if (value === 0) return 'none';
     if (value <= 10) return 'isolated patches';
     if (value <= 50) return 'sporadic';


### PR DESCRIPTION
Roughly ~4 times as small as the original using the 10 km resolution data instead of the 5 km resolution, which should help load times in transferring data to the GPU (38 MB vs 9.5 MB) on less powerful devices