### PR TITLE
Add language server protocol text editor support

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "plugins": [{
+      "name": "typescript-svelte-plugin"
+    }]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "rollup-plugin-license": "^3.0.1",
     "rollup-plugin-svelte": "^7.1.4",
     "svelte": "^3.57.0",
+    "typescript": "^5.1.6",
+    "typescript-svelte-plugin": "^0.3.29",
     "uuid": "^9.0.0",
     "vite": "^4.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,8 @@ specifiers:
   tippy.js: ^6.3.7
   topojson-client: ^3.1.0
   twgl.js: ^5.3.1
+  typescript: ^5.1.6
+  typescript-svelte-plugin: ^0.3.29
   uuid: ^9.0.0
   vite: ^4.2.1
   wcag-contrast: ^3.0.0
@@ -124,6 +126,8 @@ devDependencies:
   rollup-plugin-license: 3.0.1_rollup@3.20.2
   rollup-plugin-svelte: 7.1.4_msfiweshunp3yd3mvr5dwr2t24
   svelte: 3.57.0_4gm67c2giq6zyputvzvk4wf6oy
+  typescript: 5.1.6
+  typescript-svelte-plugin: 0.3.29_hcw2pjntgs4crb4ewl5lcqxboe
   uuid: 9.0.0
   vite: 4.2.1_4z47pm57iemvqgdkrw24muuswu
 
@@ -910,6 +914,10 @@ packages:
       ms: 2.1.2
     dev: true
 
+  /dedent-js/1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
+    dev: true
+
   /dedent/0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
@@ -1471,6 +1479,12 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
+  /lower-case/2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.6.1
+    dev: true
+
   /lru-cache/9.1.1:
     resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
     engines: {node: 14 || >=16.14}
@@ -1623,6 +1637,13 @@ packages:
     hasBin: true
     dev: true
 
+  /no-case/3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.6.1
+    dev: true
+
   /node-gyp-build-optional-packages/5.0.7:
     resolution: {integrity: sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==}
     hasBin: true
@@ -1687,6 +1708,13 @@ packages:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
     dev: false
+
+  /pascal-case/3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.1
+    dev: true
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -2093,6 +2121,18 @@ packages:
     dev: true
     patched: true
 
+  /svelte2tsx/0.6.19_hcw2pjntgs4crb4ewl5lcqxboe:
+    resolution: {integrity: sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
+      typescript: ^4.9.4 || ^5.0.0
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      svelte: 3.57.0_4gm67c2giq6zyputvzvk4wf6oy
+      typescript: 5.1.6
+    dev: true
+
   /sync-request/5.0.0:
     resolution: {integrity: sha512-NKhEA4WacR3mRBIFz1niXrIUTrUVFtP2spzrLMINangebvJ/EFyVv+LMJKvVl6UIrJM4Fburnnj91lRnqb4WkA==}
     dependencies:
@@ -2181,6 +2221,10 @@ packages:
       commander: 2.20.3
     dev: false
 
+  /tslib/2.6.1:
+    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
+    dev: true
+
   /tsscmp/1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
@@ -2199,6 +2243,22 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+    dev: true
+
+  /typescript-svelte-plugin/0.3.29_hcw2pjntgs4crb4ewl5lcqxboe:
+    resolution: {integrity: sha512-2rfeCLspu1ji4YmNtrm4KE5lJpQTerfTlqHOgFyHdAOxgOIxjtk6jbWD3C+dGd0HNuCjB9PEeWjmew5dOj1JFQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+      svelte2tsx: 0.6.19_hcw2pjntgs4crb4ewl5lcqxboe
+    transitivePeerDependencies:
+      - svelte
+      - typescript
+    dev: true
+
+  /typescript/5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
     dev: true
 
   /util-deprecate/1.0.2:


### PR DESCRIPTION
Makes it easier to navigate codebase with text editors [that support LSP](https://microsoft.github.io/language-server-protocol/implementors/tools/) and don't have a dedicated Svelte plugin. Tested with Helix.

This doesn't mean we are planning on switching to TypeScript; the added dependency is for the LSP server only.
