### PR TITLE
Avoid systemd service hitting burst limit

### DIFF
--- a/backend/systemd/fev2r-tera.service
+++ b/backend/systemd/fev2r-tera.service
@@ -11,6 +11,7 @@ WorkingDirectory=/export/data/fev2r/repository
 Environment=UV_THREADPOOL_SIZE=16
 ExecStart=/usr/local/bin/npm run tera
 Restart=on-failure
+RestartSec=1min
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Change the time between restarts after failure from the default of 100ms to 1min so that we don't get the following error:
    
      systemd[1]: start request repeated too quickly for fev2r-tera.service

Applying this PR on the prod server requires copying the `backend/systemd/fev2r-tera.service` to the path in `Loaded:` in the output of `systemctl status fev2r-tera.service`.