### PR TITLE
Update GitHub actions to use Node.js 20

### DIFF
--- a/.github/workflows/tera-status-check.yml
+++ b/.github/workflows/tera-status-check.yml
@@ -7,13 +7,13 @@ jobs:
   status-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
       - name: Check if Fluid Earth Tera backend is up and up-to-date
         run: $GITHUB_WORKSPACE/backend/scripts/status.js > $RUNNER_TEMP/out.txt
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/previous-out.txt
           key: tera-status-check-previous-output-${{ github.run_id }}
@@ -27,7 +27,7 @@ jobs:
         run: mv $RUNNER_TEMP/out.txt $RUNNER_TEMP/previous-out.txt
       - name: Save new result to cache
         if: failure()
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/previous-out.txt
           key: tera-status-check-previous-output-${{ github.run_id }}


### PR DESCRIPTION
Avoids warnings of using deprecated Node.js 16 actions

![deprecation warning as it appears under workflow runs](https://github.com/byrd-polar/fluid-earth/assets/47396035/0b7541db-49a7-41a3-bafc-1931db0bec79)
