### PR TITLE
Fix GFS backup URL not working

### DIFF
--- a/backend/download.js
+++ b/backend/download.js
@@ -15,7 +15,7 @@ export async function download(
   let file = get_temp_file(unique_path ? undefined : basename(url));
   let response = await download_as_stream(url, options);
 
-  if (response.headers['content-type'].startsWith('multipart/byteranges')) {
+  if (response.headers['content-type']?.startsWith('multipart/byteranges')) {
     await multipart_byteranges_to_file(file, response);
   } else {
     await pipeline(response, ...transforms, createWriteStream(file));


### PR DESCRIPTION
Currently FTPPRD is down, which normally wouldn't be a problem as we have logic to use NOMADS as a backup, but that was failing because our `content-type` check did not account for NOMADS not sending the header at all for `idx` files.

This fixes that and allows our GFS data to catch up again.