### PR TITLE
Fix GFS data after FTPPRD discontinuation

### DIFF
--- a/backend/sources/gfswave.js
+++ b/backend/sources/gfswave.js
@@ -1,7 +1,7 @@
 import {
   shared_metadata,
   increment_state,
-  choose_base_url,
+  base_url,
   convert_simple,
 } from './gfs.js';
 import { Datetime } from '../datetime.js';
@@ -13,16 +13,15 @@ export async function forage(current_state, datasets) {
 
   let metadatas = datasets.map(d => typical_metadata(d, dt, shared_metadata));
 
-  let base_url = choose_base_url(current_state);
-  let url = gfswave_url({ forecast, offset, system, base_url });
+  let url = gfswave_url({ forecast, offset, system });
   let compression_level = system === 'gdas' && offset < 6 ? 11 : 6;
 
   await convert_simple(url, datasets, dt, compression_level);
 
-  return { metadatas, new_state: { forecast, offset, system, base_url } };
+  return { metadatas, new_state: { forecast, offset, system } };
 }
 
-function gfswave_url({ forecast, offset, system, base_url }) {
+function gfswave_url({ forecast, offset, system }) {
   let fdt = Datetime.from(forecast);
 
   return base_url

--- a/backend/sources/rtgssthr.js
+++ b/backend/sources/rtgssthr.js
@@ -1,4 +1,4 @@
-import { choose_base_url } from './gfs.js';
+import { base_url } from './gfs.js';
 import { Datetime } from '../datetime.js';
 import { download } from '../download.js';
 import { grib2 } from '../file-conversions.js';
@@ -25,7 +25,6 @@ export async function forage(current_state, datasets) {
 
   let metadatas = datasets.map(d => typical_metadata(d, dt, metadata));
 
-  let base_url = choose_base_url(current_state);
   let url = base_url
     + 'nsst/prod/'
     + `nsst.${dt.year}${dt.p_month}${dt.p_day}/`


### PR DESCRIPTION
In theory, this shouldn't have affected us because we should auto-switch to NOMADS if FTPPRD is not available. However, the logic in 80e3932df was bad and we somehow ended up in a state where it was trying to switch to FTPPRD instead of away from it. So, let's just tear out the switching logic entirely since we no longer have two URLs that work.

See https://www.weather.gov/media/notification/pdf_2025/scn25-35_discontinue_https_access_for_FTPPRD.pdf